### PR TITLE
Force kube-proxy to bind to local address

### DIFF
--- a/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
+++ b/roles/kubernetes/node/templates/manifests/kube-proxy.manifest.j2
@@ -22,6 +22,7 @@ spec:
 {%   endif%}
     - --kubeconfig=/etc/kubernetes/node-kubeconfig.yaml
 {% endif %}
+    - --bind-address={{ ip | default(ansible_default_ipv4.address) }}
     securityContext:
       privileged: true
     volumeMounts:


### PR DESCRIPTION
In Vagrant (and potentially multi-homed environments), kubeproxy was not binding to the correct interface causing traffic access problems.