### PR TITLE
pin docker versions to 1.9 or earlier

### DIFF
--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -1,0 +1,1 @@
+docker_version: 1.9

--- a/roles/docker/vars/centos-6.yml
+++ b/roles/docker/vars/centos-6.yml
@@ -1,5 +1,7 @@
 docker_kernel_min_version: '2.6.32-431'
 
+# versioning: docker-io itself is pinned at docker 1.5
+
 docker_package_info:
   pkg_mgr: yum
   pkgs:

--- a/roles/docker/vars/debian.yml
+++ b/roles/docker/vars/debian.yml
@@ -1,10 +1,15 @@
 docker_kernel_min_version: '3.2'
-docker_version: 1.9.1-0~{{ ansible_distribution_release|lower }}
+
+# https://apt.dockerproject.org/repo/dists/debian-wheezy/main/filelist
+docker_versioned_pkg:
+  latest: docker-engine
+  1.9: docker-engine=1.9.1-0~{{ ansible_distribution_release|lower }}
+  1.10: docker-engine=1.10.0-0~{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - docker-engine={{ docker_version }}
+    - "{{ docker_versioned_pkg[docker_version] }}"
 
 docker_repo_key_info:
   pkg_key: apt_key

--- a/roles/docker/vars/fedora-20.yml
+++ b/roles/docker/vars/fedora-20.yml
@@ -1,5 +1,7 @@
 docker_kernel_min_version: '0'
 
+# versioning: docker-io itself is pinned at docker 1.5
+
 docker_package_info:
   pkg_mgr: yum
   pkgs:

--- a/roles/docker/vars/fedora.yml
+++ b/roles/docker/vars/fedora.yml
@@ -1,9 +1,13 @@
 docker_kernel_min_version: '0'
 
+docker_versioned_pkg:
+  latest: docker
+  1.9: docker-1:1.9.1
+
 docker_package_info:
   pkg_mgr: dnf
   pkgs:
-    - docker
+    - "{{ docker_versioned_pkg[docker_version] }}"
 
 docker_repo_key_info:
   pkg_key: ''

--- a/roles/docker/vars/ubuntu.yml
+++ b/roles/docker/vars/ubuntu.yml
@@ -1,10 +1,14 @@
 docker_kernel_min_version: '3.2'
-docker_version: 1.9.0-0~{{ ansible_distribution_release }}
+
+# https://apt.dockerproject.org/repo/dists/ubuntu-trusty/main/filelist
+docker_versioned_pkg:
+  latest: docker-engine
+  1.9: docker-engine=1.9.0-0~{{ ansible_distribution_release|lower }}
 
 docker_package_info:
   pkg_mgr: apt
   pkgs:
-    - docker-engine={{ docker_version }}
+    - "{{ docker_versioned_pkg[docker_version] }}"
 
 docker_repo_key_info:
   pkg_key: apt_key


### PR DESCRIPTION
Some minor changes as discussed in https://github.com/kubespray/setup-kubernetes/issues/131