### PR TITLE
confirmed working change to mktemp command

### DIFF
--- a/roles/kubernetes/secrets/scripts/make-ssl.sh
+++ b/roles/kubernetes/secrets/scripts/make-ssl.sh
@@ -54,7 +54,7 @@ if [ -z ${SSLDIR} ]; then
     SSLDIR="/etc/kubernetes/certs"
 fi
 
-tmpdir=$(mktemp -d --tmpdir kubernetes_cacert.XXXXXX)
+tmpdir=$(mktemp -d /tmp/kubernetes_cacert.XXXXXX)
 trap 'rm -rf "${tmpdir}"' EXIT
 cd "${tmpdir}"
 


### PR DESCRIPTION
This fixes #151. Instead of using the `--tmpdir` flag, which is not supported in OS X, the script will now write to /tmp/ for all OSes. Command works as expected for deploying on OS X, as well as creates temp directories as one would expect on a Ubuntu 14.04 instance.