### PR TITLE
calico: enabling nat outgoing by default

### DIFF
--- a/roles/network_plugin/calico/defaults/main.yml
+++ b/roles/network_plugin/calico/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
+# Enables Internet connectivity from containers
+nat_outgoing: true
 # cloud_provider: no

--- a/roles/network_plugin/calico/tasks/main.yml
+++ b/roles/network_plugin/calico/tasks/main.yml
@@ -48,15 +48,23 @@
   register: calico_conf
   run_once: true
 
+- name: Calico | Configure calico network pool
+  command: "{{ bin_dir }}/calicoctl pool add {{ kube_pods_subnet }}"
+  run_once: true
+  when: calico_conf.status == 404 and (cloud_provider is not defined or cloud_provider != True)
+        and not nat_outgoing|default(false) or
+        (nat_outgoing|default(false) and peer_with_router|default(false))
+
 - name: Calico | Configure calico network pool for cloud
   command: "{{ bin_dir }}/calicoctl pool add {{ kube_pods_subnet }} --ipip --nat-outgoing"
   run_once: true
   when: calico_conf.status == 404 and cloud_provider is defined and cloud_provider == True
 
-- name: Calico | Configure calico network pool
-  command: "{{ bin_dir }}/calicoctl pool add {{ kube_pods_subnet }}"
+- name: Calico | Configure calico network pool with nat outgoing
+  command: "{{ bin_dir}}/calicoctl pool add {{ kube_pods_subnet }} --nat-outgoing"
   run_once: true
   when: calico_conf.status == 404 and (cloud_provider is not defined or cloud_provider != True)
+        and nat_outgoing|default(false) and not peer_with_router|default(false)
 
 - name: Calico | Get calico configuration from etcd
   uri:


### PR DESCRIPTION
By default Internet connectivity isn't working from containers.
This is the purpose of the option `--nat-outgoing`.

It can be disabled if necessary with the variable
```
nat_outgoing: false
```

default value is true