### PR TITLE
On CoreOS, /etc/hosts does not always exist.

### DIFF
--- a/roles/kubernetes/preinstall/tasks/etchosts.yml
+++ b/roles/kubernetes/preinstall/tasks/etchosts.yml
@@ -5,6 +5,7 @@
     regexp: "^{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item].ansible_default_ipv4.address)) }} {{ item }}$"
     line: "{{ hostvars[item]['access_ip'] | default(hostvars[item]['ip'] | default(hostvars[item].ansible_default_ipv4.address)) }} {{ item }}"
     state: present
+    create: yes
     backup: yes
   when: hostvars[item].ansible_default_ipv4.address is defined
   with_items: groups['all']


### PR DESCRIPTION
A fresh install of CoreOS doesn't appear to include /etc/hosts by default.  Set the flag to lineinfile to create it if it does not exist.